### PR TITLE
Option to provide className to span

### DIFF
--- a/lib.jsx
+++ b/lib.jsx
@@ -6,6 +6,6 @@ TAP = React.createClass({
     };
   },
   render() {
-    return <span>{this.data.text}</span>
+    return <span className={this.props.className}>{this.data.text}</span>
   }
 });


### PR DESCRIPTION
Adds option to provide className when instantiating the react component. These classes are added to the span wrapping the returning text.
