### PR TITLE
Option to provide custom DOM wrapper, classNames to attach and to render as HTML

### DIFF
--- a/lib.jsx
+++ b/lib.jsx
@@ -6,14 +6,42 @@ TAP = React.createClass({
     };
   },
   render() {
+
+    var additionalProps = _.omit(this.props, [
+      'tag',
+      'label',
+      'options',
+      'renderHTML'
+    ]);
+
     if (this.props.tag) {
-      return React.createElement(
-        this.props.tag,
-        { className: this.props.className },
-        this.data.text
-      );
+      if (this.props.renderHTML) {
+        return React.createElement(
+          this.props.tag,
+          _.extend(additionalProps, {
+            dangerouslySetInnerHTML: {__html: this.data.text}
+          })
+        );
+      } else {
+        return React.createElement(
+          this.props.tag,
+          additionalProps,
+          this.data.text
+        );
+      }
     } else {
-      return <span className={this.props.className}>{this.data.text}</span>
+      if (this.props.renderHTML) {
+        return (
+          <span
+            {...additionalProps}
+            dangerouslySetInnerHTML={{
+              __html: this.data.text
+            }}>
+          </span>
+        );
+      } else {
+        return <span {...additionalProps}>{this.data.text}</span>;
+      }
     }
   }
 });

--- a/lib.jsx
+++ b/lib.jsx
@@ -6,6 +6,14 @@ TAP = React.createClass({
     };
   },
   render() {
-    return <span>{this.data.text}</span>
+    if (this.props.tag) {
+      return React.createElement(
+        this.props.tag,
+        { className: this.props.className },
+        this.data.text
+      );
+    } else {
+      return <span className={this.props.className}>{this.data.text}</span>
+    }
   }
 });


### PR DESCRIPTION
This PR resolves issues #3, #4 and #6 and contain these changes:
- Adds option to provide which kind of DOM element to render as wrapper for the text. 
- Adds option to provide className when instantiating the react component. These classes are added to the DOM element wrapping the returning text. 
- Adds option to render text as HTML.

**Usage:**

``` html
<TAP tag="h2" className="welcome-title" renderHTML={true} label="index.welcome_header" options={{ username: 'React' }}/>
```
